### PR TITLE
OER-27 Find a way to display all tags all tags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Multisite Taxonomies",
+  "name": "harvardchanschool/multisite_taxonomies",
   "type": "wordpress-plugin",
   "description": "",
   "homepage": "https://github.com/HarvardChanSchool/multisite-taxonomies",

--- a/inc/class-multisite-taxonomy-meta-box.php
+++ b/inc/class-multisite-taxonomy-meta-box.php
@@ -430,15 +430,19 @@ class Multisite_Taxonomy_Meta_Box {
 			wp_die( -1 );
 		}
 
-		$terms = get_multisite_terms(
-			array(
-				'taxonomy'   => $taxonomy,
-				'number'     => 300,
-				'orderby'    => 'count',
-				'order'      => 'DESC',
-				'hide_empty' => false,
-			)
+		$term_args = array(
+			'taxonomy'   => $taxonomy,
+			'number'     => 45,
+			'orderby'    => 'count',
+			'order'      => 'DESC',
+			'hide_empty' => false,
 		);
+
+		// Make the multisite term cloud defaults editable.
+		$term_args = apply_filters( 'multisite_taxonomy_term_cloud_args', $term_args );
+
+		// Get the terms for the clould.
+		$terms = get_multisite_terms( $term_args );
 
 		if ( empty( $terms ) ) {
 			wp_die( esc_html( $tax->labels->not_found ) );

--- a/inc/class-multisite-taxonomy-meta-box.php
+++ b/inc/class-multisite-taxonomy-meta-box.php
@@ -433,7 +433,7 @@ class Multisite_Taxonomy_Meta_Box {
 		$terms = get_multisite_terms(
 			array(
 				'taxonomy'   => $taxonomy,
-				'number'     => 45,
+				'number'     => 300,
 				'orderby'    => 'count',
 				'order'      => 'DESC',
 				'hide_empty' => false,

--- a/inc/class-multitaxo-plugin.php
+++ b/inc/class-multitaxo-plugin.php
@@ -407,7 +407,7 @@ class Multitaxo_Plugin {
 					);
 				}
 
-				if ( isset( $_REQUEST['delete_multisite_terms'] ) && is_array( wp_unslash( $_REQUEST['delete_multisite_terms'] ) ) ) {
+				if ( isset( $_REQUEST['delete_multisite_terms'] ) && is_array( wp_unslash( $_REQUEST['delete_multisite_terms'] ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
 					$multisite_terms = array_map( 'absint', wp_unslash( $_REQUEST['delete_multisite_terms'] ) );
 					foreach ( $multisite_terms as $multisite_terms_id ) {
 						delete_multisite_term( $multisite_terms_id, $mulsite_taxonomy->name );
@@ -422,7 +422,7 @@ class Multitaxo_Plugin {
 					break;
 				}
 
-				$multisite_term_id = (int) absint( wp_unslash( $_POST['multisite_term_id'] ) );
+				$multisite_term_id = (int) absint( wp_unslash( $_POST['multisite_term_id'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
 				$term              = get_multisite_term( $multisite_term_id );
 
 				if ( ! $term instanceof WP_Term ) {
@@ -433,7 +433,11 @@ class Multitaxo_Plugin {
 
 				exit;
 			case 'editedtag':
-				$tag_id = (int) absint( wp_unslash( $_POST['multisite_term_id'] ) );
+				if ( ! isset( $_REQUEST['multisite_term_id'] ) ) {
+					break;
+				}
+
+				$tag_id = (int) absint( wp_unslash( $_POST['multisite_term_id'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
 
 				check_admin_referer( 'update-multisite-term_' . $tag_id );
 


### PR DESCRIPTION
Increase the limit of the tags to 300 so that all are displayed. If a section has more than 300 tags it will need to have the limit increased again but this should do for now.

https://dev1.sph.harvard.edu/news/wp-admin/post.php?post=111354842740&action=edit

- Under topics all are displayed
- Under tags "donor profile" is being displayed even though it has 0 articles it is being used on.