### PR TITLE
Allows meta box with suggestion to work in the block editor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "dol-lab/multisite_taxonomies",
+  "name": "harvardchanschool/multisite_taxonomies",
   "type": "wordpress-plugin",
   "description": "",
   "homepage": "https://github.com/HarvardChanSchool/multisite-taxonomies",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "harvardchanschool/multisite_taxonomies",
+  "name": "dol-lab/multisite_taxonomies",
   "type": "wordpress-plugin",
   "description": "",
   "homepage": "https://github.com/HarvardChanSchool/multisite-taxonomies",

--- a/inc/class-multisite-taxonomy-meta-box.php
+++ b/inc/class-multisite-taxonomy-meta-box.php
@@ -57,7 +57,7 @@ class Multisite_Taxonomy_Meta_Box {
 			return;
 		}
 
-		wp_enqueue_script( 'multisite-taxonomy-suggest', MULTITAXO_ASSETS_URL . '/js/multisite-taxonomy-suggest.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-autocomplete', 'wp-a11y' ), MULTITAXO_VERSION, 1 );
+		wp_enqueue_script( 'multisite-taxonomy-suggest', MULTITAXO_ASSETS_URL . '/js/multisite-taxonomy-suggest.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-autocomplete', 'wp-a11y', 'tags-suggest' ), MULTITAXO_VERSION, 1 );
 		wp_localize_script(
 			'multisite-taxonomy-suggest',
 			'multiTaxL10n',

--- a/inc/class-multitaxo-plugin.php
+++ b/inc/class-multitaxo-plugin.php
@@ -67,6 +67,10 @@ class Multitaxo_Plugin {
 		$wpdb->multisite_terms                   = $wpdb->base_prefix . 'multisite_terms';
 		$wpdb->multisite_term_relationships      = $wpdb->base_prefix . 'multisite_term_relationships';
 		$wpdb->multisite_term_multisite_taxonomy = $wpdb->base_prefix . 'multisite_term_multisite_taxonomy';
+
+		if ( false === get_site_option( 'multitaxo_tables_created' ) ) {
+			$this->create_database_tables();
+		}
 	}
 
 	/**
@@ -114,7 +118,6 @@ class Multitaxo_Plugin {
 	 */
 	public function activation_hook() {
 		$this->register_database_tables();
-		$this->create_database_tables();
 	}
 
 	/**
@@ -162,7 +165,8 @@ class Multitaxo_Plugin {
 			KEY meta_key (meta_key(' . $max_index_length . '))
 		) ' . $charset_collate . ';';
 
-		dbDelta( $multisite_termmeta_sql );
+		//dbDelta( $multisite_termmeta_sql );
+		$wpdb->query( $multisite_termmeta_sql );
 
 		// Table structure for table `wp_multisite_terms`.
 		$multisite_terms_sql = 'CREATE TABLE IF NOT EXISTS `' . $wpdb->multisite_terms . '` (
@@ -175,7 +179,8 @@ class Multitaxo_Plugin {
 			KEY name (name(' . $max_index_length . '))
 		) ' . $charset_collate . ';';
 
-		dbDelta( $multisite_terms_sql );
+		//dbDelta( $multisite_terms_sql );
+		$wpdb->query( $multisite_terms_sql );
 
 		// Table structure for table `wp_multisite_term_relationships`.
 		$multisite_term_relationships_sql = 'CREATE TABLE IF NOT EXISTS `' . $wpdb->multisite_term_relationships . '` (
@@ -183,11 +188,12 @@ class Multitaxo_Plugin {
 			object_id bigint(20) unsigned NOT NULL default 0,
 			multisite_term_multisite_taxonomy_id bigint(20) unsigned NOT NULL default 0,
 			multisite_term_order int(11) NOT NULL default 0,
-			PRIMARY KEY (blog_id,object_id,multisite_term_multisite_taxonomy_id),
+			PRIMARY KEY  (blog_id,object_id,multisite_term_multisite_taxonomy_id),
 			KEY multisite_term_multisite_taxonomy_id (multisite_term_multisite_taxonomy_id)
 		) ' . $charset_collate . ';';
 
-		dbDelta( $multisite_term_relationships_sql );
+		//dbDelta( $multisite_term_relationships_sql );
+		$wpdb->query( $multisite_term_relationships_sql );
 
 		// Table structure for table `wp_multisite_term_multisite_taxonomy`.
 		$multisite_term_multisite_taxonomy_sql = 'CREATE TABLE IF NOT EXISTS `' . $wpdb->multisite_term_multisite_taxonomy . '` (
@@ -202,7 +208,11 @@ class Multitaxo_Plugin {
 			KEY multisite_taxonomy (multisite_taxonomy)
 		) ' . $charset_collate . ';';
 
-		dbDelta( $multisite_term_multisite_taxonomy_sql );
+		//dbDelta( $multisite_term_multisite_taxonomy_sql );
+		$wpdb->query( $multisite_term_multisite_taxonomy_sql );
+
+		update_site_option( 'multitaxo_tables_created', 1 );
+
 	}
 
 	/**

--- a/inc/multisite-taxonomy-template.php
+++ b/inc/multisite-taxonomy-template.php
@@ -24,6 +24,7 @@
  *                                        the top of the list. Default true.
  *     @type bool   $echo                 Whether to echo the generated markup. False to return the markup instead
  *                                        of echoing it. Default true.
+ * @return string   $output               Unordered list of checkboxes.
  * }
  */
 function multisite_terms_checklist( $post_id = 0, $args = array() ) {


### PR DESCRIPTION
Making `tags-suggest` (bundled with WordPress) a dependency allows the legacy meta box to work with the new block editor.