### PR TITLE
Add legacy js dependency, see original PR #57 for reference

### DIFF
--- a/inc/class-multisite-taxonomy-meta-box.php
+++ b/inc/class-multisite-taxonomy-meta-box.php
@@ -57,7 +57,7 @@ class Multisite_Taxonomy_Meta_Box {
 			return;
 		}
 
-		wp_enqueue_script( 'multisite-taxonomy-suggest', MULTITAXO_ASSETS_URL . '/js/multisite-taxonomy-suggest.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-autocomplete', 'wp-a11y' ), MULTITAXO_VERSION, 1 );
+		wp_enqueue_script( 'multisite-taxonomy-suggest', MULTITAXO_ASSETS_URL . '/js/multisite-taxonomy-suggest.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-autocomplete', 'wp-a11y', 'tags-suggest' ), MULTITAXO_VERSION, 1 );
 		wp_localize_script(
 			'multisite-taxonomy-suggest',
 			'multiTaxL10n',


### PR DESCRIPTION
Title: Allows meta box with suggestion to work in the block editor, see #57 

Making `tags-suggest` (bundled with WordPress) a dependency allows the legacy meta box to work with the new block editor.