### PR TITLE
Fixing Javascript errors after WP 5.5 update COM-212

### DIFF
--- a/assets/js/multisite-taxonomy-box.js
+++ b/assets/js/multisite-taxonomy-box.js
@@ -4,7 +4,7 @@
 var multiTagBox, array_multi_unique_noempty;
 
 ( function( $ ) {
-	var tagDelimiter = ( window.tagsSuggestL10n && window.tagsSuggestL10n.tagDelimiter ) || ',';
+	var tagDelimiter = ( window.multiTaxL10n && window.multiTaxL10n.tagDelimiter ) || ',';
 
 	// Return an array with any duplicate, whitespace or empty values removed
 	array_multi_unique_noempty = function( array ) {
@@ -96,7 +96,7 @@ var multiTagBox, array_multi_unique_noempty;
 					 */
 					xbutton = $( '<button type="button" id="' + id + '-check-num-' + key + '" class="ntmultidelbutton">' +
 						'<span class="remove-multi-tag-icon" aria-hidden="true"></span>' +
-						'<span class="screen-reader-text">' + window.tagsSuggestL10n.removeTerm + ' ' + listItem.html() + '</span>' +
+						'<span class="screen-reader-text">' + window.multiTaxL10n.removeTerm + ' ' + listItem.html() + '</span>' +
 						'</button>' );
 
 					xbutton.on( 'click keypress', function( e ) {
@@ -199,11 +199,11 @@ var multiTagBox, array_multi_unique_noempty;
 
 			switch ( this.userAction ) {
 				case 'remove':
-					message = window.tagsSuggestL10n.termRemoved;
+					message = window.multiTaxL10n.termRemoved;
 					break;
 
 				case 'add':
-					message = window.tagsSuggestL10n.termAdded;
+                    message = window.multiTaxL10n.termAdded;
 					break;
 
 				default:

--- a/assets/js/multisite-taxonomy-suggest.js
+++ b/assets/js/multisite-taxonomy-suggest.js
@@ -2,12 +2,12 @@
  * Default settings for jQuery UI Autocomplete for use with non-hierarchical taxonomies.
  */
 ( function( $ ) {
-	if ( typeof window.tagsSuggestL10n === 'undefined' || typeof window.uiAutocompleteL10n === 'undefined' ) {
+	if ( typeof window.multiTaxL10n === 'undefined' || typeof window.uiAutocompleteL10n === 'undefined' ) {
 		return;
 	}
 
 	var tempID = 0;
-	var separator = window.tagsSuggestL10n.tagDelimiter || ',';
+	var separator = window.multiTaxL10n.tagDelimiter || ',';
 
 	function split( val ) {
 		return val.split( new RegExp( separator + '\\s*' ) );
@@ -103,7 +103,7 @@
 
 				if ( $.ui.keyCode.TAB === event.keyCode ) {
 					// Audible confirmation message when a tag has been selected.
-					window.wp.a11y.speak( window.tagsSuggestL10n.termSelected, 'assertive' );
+					window.wp.a11y.speak( window.multiTaxL10n.termSelected, 'assertive' );
 					event.preventDefault();
 				} else if ( $.ui.keyCode.ENTER === event.keyCode ) {
 					// Do not close Quick Edit / Bulk Edit

--- a/multisite-taxonomies.php
+++ b/multisite-taxonomies.php
@@ -9,7 +9,7 @@
  * Plugin Name: Multisite Taxonomies
  * Plugin URI:  https://github.com/HarvardChanSchool/multisite-taxonomies
  * Description: Multisite Taxonomies brings the ability to register custom taxonomies, accessible on an entire multisite network, to WordPress.
- * Version:     0.0.1
+ * Version:     0.0.2
  * Author:      Harvard Chan Webteam
  * Author URI:  http://www.hsph.harvard.edu/information-technology/
  * Text Domain: multitaxo


### PR DESCRIPTION
Description
----------------
The current build is throwing JavaScript errors that are preventing users to use the add multisite term meta box. 

<img width="1080" alt="Screen Shot 2020-08-18 at 1 12 49 PM" src="https://user-images.githubusercontent.com/1478527/90544040-8e5a3380-e154-11ea-8bf3-75eeb72e09cf.png">

Background: I think this was caused by some changes in WP 5.5, since we were leveraging a lot of WP Core Taxonomies names and functions, this was likely working because some of these vars were likley defined by Core. They have likely been renamed or refactored in core and it broke. We are now using the correct variables and function names.

Requirements
------------
<!--List anything needed to test that is not part of the standard HSPH local development environment-->

**Branches:**
<!--List any required branches in this format: repository-name/branch-name-->

1. This plugin should already network activated.
2. Should be tested on the news site (biggest user of the plugin).
3. Need specific user privilege to be able to do this. If you don't see the box you might not have the correct permissions. 

Test Steps
----------
<!--Be explicit. Use screenshots if necessary. Don't assume the reviewer knows what you know-->

1. On master branch: https://dev1.sph.harvard.edu/news/wp-admin/post.php?post=111354850106&action=edit editing multisite terms should not be possible, you should see errors in the browser dev console.
2. On this branch, everything should be working again.

Related
-----------------
**Jira Issues**

<!--List issue numbers here. Ex: ABC-1234-->

1. COM-212


<!--**ServiceNow tickets**-->

  <!--List ticket numbers here. Ex: INC01234567-->


<!--**Wiki articles**-->

  <!--Link to any related Wiki articles-->


<!--**Other**-->

  <!--Any other related materials-->
