### PR TITLE
Fixed fatal error caused by join() param order DWOPS-267

### DIFF
--- a/inc/class-multisite-taxonomy-meta-box.php
+++ b/inc/class-multisite-taxonomy-meta-box.php
@@ -404,7 +404,7 @@ class Multisite_Taxonomy_Meta_Box {
 			)
 		);
 
-		echo join( $results, "\n" ); // phpcs:ignore WordPress.Security.EscapeOutput
+		echo join( "\n", $results ); // phpcs:ignore WordPress.Security.EscapeOutput
 		wp_die();
 	}
 

--- a/inc/class-multisite-taxonomy-meta-box.php
+++ b/inc/class-multisite-taxonomy-meta-box.php
@@ -404,7 +404,7 @@ class Multisite_Taxonomy_Meta_Box {
 			)
 		);
 
-		echo join( "\n", $results ); // phpcs:ignore WordPress.Security.EscapeOutput
+		echo implode( "\n", $results ); // phpcs:ignore WordPress.Security.EscapeOutput
 		wp_die();
 	}
 


### PR DESCRIPTION

Description
----------------
<!--Describe what this PR does in 1-2 sentences-->

In php7x the existing param order only caused a warning. In php8x it causes a fatal error, and needs to be fixed before we migrate to php8x.

Requirements
------------
<!--List anything needed to test that is not part of the standard HSPH local development environment-->

**Branches:**
<!--List any required branches in this format: repository-name/branch-name-->

1. This branch

Test Steps
----------
<!--Be explicit. Use screenshots if necessary. Don't assume the reviewer knows what you know-->

1. Steps to reproduce the error are in the Jira ticket.
2. To test the fix, checkout this branch.
3. Attempt to reproduce the fatal error again.

Web Accessibility 
----------------
<!--All changes introduced in this PR meet our web accessibility guidelines -->

- [x] All changes in this PR conform with the current version of our [Web Accessibility PR Checklist](https://wiki.harvard.edu/confluence/pages/viewpage.action?spaceKey=HSPHWeb&title=Web+Accessibility+PR+Checklist).