### PR TITLE
Return the multisite-taxonomy-object on register_multisite_taxonomy WP-1984

### DIFF
--- a/inc/multisite-taxonomy.php
+++ b/inc/multisite-taxonomy.php
@@ -200,7 +200,7 @@ function is_multisite_taxonomy_hierarchical( $multisite_taxonomy ) {
  *     @type callable      $update_count_callback Works much like a hook, in that it will be called when the count is
  *                                                updated. Default update_multisite_term_count().
  * }
- * @return WP_Error|void WP_Error, if errors.
+ * @return Multisite_Taxonomy|WP_Error The registered multisite taxonomy object on success, WP_Error object on failure.
  */
 function register_multisite_taxonomy( $multisite_taxonomy, $object_type, $args = array() ) {
 	global $multisite_taxonomies;
@@ -230,6 +230,8 @@ function register_multisite_taxonomy( $multisite_taxonomy, $object_type, $args =
 	 * @param array        $args        Array of multisite taxonomy registration arguments.
 	 */
 	do_action( 'registered_multisite_taxonomy', $multisite_taxonomy, $object_type, (array) $multisite_taxonomy_object );
+
+	return $multisite_taxonomy_object;
 }
 
 /**


### PR DESCRIPTION
Thank you for your work on this plugin!

I recently rewrote a plugin to use multisite-taxonomies and came across this difference (between the way WordPress handles taxonomies and this plugin does it):
WordPress returns the newly registered taxonomy object [in the function register_taxonomy](https://github.com/WordPress/WordPress/blob/master/wp-includes/taxonomy.php#L477).

This PR adds the same "feature" to multisite taxonomies (to be closer to WordPress).